### PR TITLE
remove trailing spaces comming from events form

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -191,6 +191,8 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     $this->_lineItem = $this->get('lineItem');
     $this->_isEventFull = $this->get('isEventFull');
     $this->_lineItemParticipantsCount = $this->get('lineItemParticipants');
+    $this->applyFilter('__ALL__', 'trim');
+
     if (!is_array($this->_lineItem)) {
       $this->_lineItem = array();
     }


### PR DESCRIPTION
Whenever one or several blank spaces are added to the start or ende of first_name, last_name or email fields, they are saved to the database, which messes with the dedup function and probably some others. This patch uses the civi function to trim those blank spaces.

patch sponsored by palantetech.coop :-p